### PR TITLE
Add flexible DataTable demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
+    "@tanstack/react-table": "^8.21.3",
     "node-sass": "4.14.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/ExampleApp.js
+++ b/src/ExampleApp.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import DataTableDemo from './components/demo/DataTableDemo';
+
+export default function ExampleApp() {
+  return <DataTableDemo />;
+}

--- a/src/components/demo/DataTableDemo.js
+++ b/src/components/demo/DataTableDemo.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import DataTable from '../table/DataTable';
+
+const columns = [
+  { accessorKey: 'id', header: 'ID', size: 50 },
+  { accessorKey: 'firstName', header: 'First name', editable: true, inputType: 'text', filterable: true },
+  { accessorKey: 'lastName', header: 'Last name', editable: true, inputType: 'text', filterable: true },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    editable: true,
+    inputType: 'select',
+    options: [
+      { value: 'active', label: 'Active' },
+      { value: 'inactive', label: 'Inactive' },
+    ],
+  },
+];
+
+const data = [
+  { id: 1, firstName: 'John', lastName: 'Doe', status: 'active' },
+  { id: 2, firstName: 'Jane', lastName: 'Smith', status: 'inactive' },
+  { id: 3, firstName: 'Alice', lastName: 'Brown', status: 'active' },
+];
+
+const actions = [
+  { label: 'Edit', onClick: row => alert('Edit ' + row.id) },
+];
+
+export default function DataTableDemo() {
+  return <DataTable columnsDefinition={columns} data={data} enableRowSelection rowActions={actions} />;
+}

--- a/src/components/table/DataTable.js
+++ b/src/components/table/DataTable.js
@@ -1,0 +1,208 @@
+import React, { useMemo, useState } from 'react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+  getExpandedRowModel,
+} from '@tanstack/react-table';
+
+
+function DefaultInput({ value: initialValue, row, column, updateData, type, options }) {
+  const [value, setValue] = useState(initialValue);
+  const onChange = e => setValue(e.target.value);
+  const onBlur = () => updateData(row.index, column.id, value);
+
+  if (type === 'select') {
+    return (
+      <select value={value} onChange={onChange} onBlur={onBlur}>
+        {options && options.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    );
+  }
+
+  if (type === 'multiselect') {
+    return (
+      <select multiple value={value} onChange={e => {
+        const opts = Array.from(e.target.selectedOptions).map(o => o.value);
+        setValue(opts);
+      }} onBlur={onBlur}>
+        {options && options.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    );
+  }
+
+  return <input value={value} onChange={onChange} onBlur={onBlur} />;
+}
+
+function DataTable({ columnsDefinition, data, enableRowSelection = false, rowActions = [] }) {
+  const [tableData, setTableData] = useState(data);
+  const [columnVisibility, setColumnVisibility] = useState({});
+  const [columnFilters, setColumnFilters] = useState([]);
+  const [sorting, setSorting] = useState([]);
+  const [expanded, setExpanded] = useState({});
+  const [rowSelection, setRowSelection] = useState({});
+
+  const updateData = (rowIndex, columnId, value) => {
+    setTableData(old => old.map((row, index) => {
+      if (index === rowIndex) {
+        return { ...row, [columnId]: value };
+      }
+      return row;
+    }));
+  };
+
+  const columns = useMemo(() => {
+    return columnsDefinition.map(col => {
+      return {
+        accessorKey: col.accessorKey,
+        header: col.header,
+        size: col.size,
+        enableColumnFilter: col.filterable,
+        cell: col.render
+          ? col.render
+          : ({ getValue, row, column }) => {
+              const initialValue = getValue();
+              if (col.editable) {
+                return (
+                  <DefaultInput
+                    value={initialValue}
+                    row={row}
+                    column={column}
+                    updateData={updateData}
+                    type={col.inputType}
+                    options={col.options}
+                  />
+                );
+              }
+              return String(initialValue ?? '');
+            },
+      };
+    });
+  }, [columnsDefinition, updateData]);
+
+  const table = useReactTable({
+    data: tableData,
+    columns,
+    state: {
+      columnVisibility,
+      columnFilters,
+      sorting,
+      expanded,
+      rowSelection,
+    },
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting,
+    onExpandedChange: setExpanded,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    enableRowSelection,
+  });
+
+  return (
+    <div className="datatable-container">
+      <table className="datatable">
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {enableRowSelection && headerGroup.headers.length && (
+                <th>
+                  <input
+                    type="checkbox"
+                    {...{
+                      checked: table.getIsAllRowsSelected(),
+                      indeterminate: table.getIsSomeRowsSelected(),
+                      onChange: table.getToggleAllRowsSelectedHandler(),
+                    }}
+                  />
+                </th>
+              )}
+              {headerGroup.headers.map(header => (
+                <th key={header.id} style={{ width: header.getSize() }}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                  {header.column.getCanFilter() ? (
+                    <div>
+                      <input
+                        type="text"
+                        value={(header.column.getFilterValue() ?? '')}
+                        onChange={e => header.column.setFilterValue(e.target.value)}
+                        placeholder="Filter"
+                      />
+                    </div>
+                  ) : null}
+                </th>
+              ))}
+              {rowActions.length > 0 && <th>Actions</th>}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <React.Fragment key={row.id}>
+              <tr>
+                {enableRowSelection && (
+                  <td>
+                    <input
+                      type="checkbox"
+                      {...{
+                        checked: row.getIsSelected(),
+                        disabled: !row.getCanSelect(),
+                        onChange: row.getToggleSelectedHandler(),
+                      }}
+                    />
+                  </td>
+                )}
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id} style={{ width: cell.column.getSize() }}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+                {rowActions.length > 0 && (
+                  <td>
+                    {rowActions.map(action => (
+                      <button key={action.label} onClick={() => action.onClick(row.original)}>
+                        {action.label}
+                      </button>
+                    ))}
+                  </td>
+                )}
+              </tr>
+              {row.getIsExpanded() && row.subRows && (
+                <tr>
+                  <td colSpan={row.getVisibleCells().length + (enableRowSelection ? 1 : 0) + (rowActions.length > 0 ? 1 : 0)}>
+                    <table className="datatable nested">
+                      <tbody>
+                        {row.subRows.map(subRow => (
+                          <tr key={subRow.id}>
+                            {subRow.getVisibleCells().map(cell => (
+                              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/src/components/table/DataTable.test.js
+++ b/src/components/table/DataTable.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DataTable from './DataTable';
+
+const columns = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+];
+
+const data = [
+  { id: 1, name: 'First' },
+];
+
+test('renders table with data', () => {
+  render(<DataTable columnsDefinition={columns} data={data} />);
+  expect(screen.getByText('First')).toBeInTheDocument();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 //import './index.css';
 import './sass/index.scss';
-import App from './App';
+import ExampleApp from './ExampleApp';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ExampleApp />
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/sass/components/_datatable.scss
+++ b/src/sass/components/_datatable.scss
@@ -1,0 +1,30 @@
+.datatable-container {
+  overflow-x: auto;
+}
+
+.datatable {
+  border-collapse: collapse;
+  width: 100%;
+  color: #333;
+  font-size: 14px;
+}
+
+.datatable th,
+.datatable td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.datatable th {
+  background-color: #f2f2f2;
+  position: relative;
+}
+
+.datatable input[type='text'],
+.datatable select {
+  width: 100%;
+}
+
+.datatable.nested {
+  margin-top: 10px;
+}

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -9,3 +9,4 @@
 @import "components/navbar";
 @import "components/portfolio";
 @import "components/team";
+@import "components/datatable";


### PR DESCRIPTION
## Summary
- add TanStack Table to dependencies
- implement `DataTable` component
- style table with neutral colors
- demo component with sample data
- render demo via new `ExampleApp`
- basic test for table rendering

## Testing
- `npm test -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684d1ec4f0832ebc8f900670856ab8